### PR TITLE
feat(security): add JWT filter and stateless security config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       MONGO_USER: root
       MONGO_PASS: example
       MONGO_AUTHDB: admin
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
 
     steps:
       - name: Checkout repo

--- a/tasks-svc/pom.xml
+++ b/tasks-svc/pom.xml
@@ -62,7 +62,27 @@
             <version>2.7.0</version>
         </dependency>
 
-
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
 
 
     </dependencies>

--- a/tasks-svc/src/main/java/com/santiago/tasks/config/SecurityConfig.java
+++ b/tasks-svc/src/main/java/com/santiago/tasks/config/SecurityConfig.java
@@ -1,4 +1,38 @@
 package com.santiago.tasks.config;
 
+
+import com.santiago.tasks.security.JwtFilter;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
 public class SecurityConfig {
+
+    private final JwtFilter jwtFilter;
+
+    public SecurityConfig(JwtFilter jwtFilter) {
+        this.jwtFilter = jwtFilter;
+    }
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .requestCache(rc -> rc.disable())
+                .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+                .exceptionHandling(ex -> ex.authenticationEntryPoint(
+                        (req, res, e) -> res.sendError(HttpServletResponse.SC_UNAUTHORIZED)
+                ))
+                .httpBasic(b -> b.disable())
+                .formLogin(f -> f.disable())
+                .logout(l -> l.disable())
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
 }

--- a/tasks-svc/src/main/java/com/santiago/tasks/config/SecurityConfig.java
+++ b/tasks-svc/src/main/java/com/santiago/tasks/config/SecurityConfig.java
@@ -1,0 +1,4 @@
+package com.santiago.tasks.config;
+
+public class SecurityConfig {
+}

--- a/tasks-svc/src/main/java/com/santiago/tasks/controller/TaskController.java
+++ b/tasks-svc/src/main/java/com/santiago/tasks/controller/TaskController.java
@@ -4,6 +4,7 @@ import com.santiago.tasks.DTO.CreateTaskRequest;
 import com.santiago.tasks.DTO.UpdateTaskRequest;
 import com.santiago.tasks.domain.Task;
 import com.santiago.tasks.service.TaskService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -24,8 +25,9 @@ public class TaskController {
 
     @PostMapping
     public Task createTask(
-            @RequestHeader("X-USER-ID") String userId,
+            HttpServletRequest request,
             @Valid @RequestBody CreateTaskRequest req) {
+        String userId = request.getAttribute("userId").toString();
         return taskService.createTask(userId, req);
     }
 

--- a/tasks-svc/src/main/java/com/santiago/tasks/security/JwtFilter.java
+++ b/tasks-svc/src/main/java/com/santiago/tasks/security/JwtFilter.java
@@ -1,0 +1,4 @@
+package com.santiago.tasks.security;
+
+public class JwtFilter {
+}

--- a/tasks-svc/src/main/java/com/santiago/tasks/security/JwtFilter.java
+++ b/tasks-svc/src/main/java/com/santiago/tasks/security/JwtFilter.java
@@ -1,4 +1,66 @@
 package com.santiago.tasks.security;
 
-public class JwtFilter {
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import java.io.IOException;
+import java.security.Key;
+import java.util.List;
+
+import io.jsonwebtoken.JwtException;
+
+@Component
+public class JwtFilter extends OncePerRequestFilter {
+
+
+    private Key secretKey;
+
+    public JwtFilter(@Value("${jwt.secret}") String secret) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String header = request.getHeader("Authorization");
+        if (header == null || !header.startsWith("Bearer ")) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        String token = header.substring(7);
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(secretKey).build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            String userId = claims.getSubject();
+
+            var auth = new UsernamePasswordAuthenticationToken(
+                    userId, null, List.of()
+            );
+            SecurityContextHolder.getContext().setAuthentication(auth);
+
+            request.setAttribute("userId", userId);
+        }  catch (JwtException e) {
+        System.out.println("JWT error: " + e.getClass().getSimpleName() + " - " + e.getMessage());
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        return;
+    }
+
+        filterChain.doFilter(request, response);
+    }
 }

--- a/tasks-svc/src/main/resources/application.properties
+++ b/tasks-svc/src/main/resources/application.properties
@@ -4,3 +4,6 @@ spring.data.mongodb.database=${MONGO_DB:tasksdb}
 spring.data.mongodb.username=${MONGO_USER:root}
 spring.data.mongodb.password=${MONGO_PASS:example}
 spring.data.mongodb.authentication-database=${MONGO_AUTHDB:admin}
+jwt.secret=${JWT_SECRET}
+logging.level.com.santiago.tasks=DEBUG
+logging.level.org.springframework.security=DEBUG

--- a/tasks-svc/src/test/java/com/santiago/tasks/TaskControllerValidationTest.java
+++ b/tasks-svc/src/test/java/com/santiago/tasks/TaskControllerValidationTest.java
@@ -5,13 +5,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
+@SpringBootTest(properties = {
+        "jwt.secret=0123456789_0123456789_0123456789__OK"
+})
+@AutoConfigureMockMvc(addFilters = false)
 public class TaskControllerValidationTest {
 
     @Autowired
@@ -30,10 +30,9 @@ public class TaskControllerValidationTest {
   """;
 
         mockMvc.perform(post("/tasks")
-                        .header("X-USER-ID", "Santi")
+                        .requestAttr("userId", "Santi")
                         .contentType("application/json")
                         .content(body))
-                .andDo(print())
                 .andExpect(status().isBadRequest());
     }
 
@@ -51,10 +50,9 @@ public class TaskControllerValidationTest {
         """;
 
         mockMvc.perform(post("/tasks")
-                        .header("X-USER-ID", "Santi")
+                        .requestAttr("userId", "Santi")
                         .contentType("application/json")
                         .content(body))
-                .andDo(print())
                 .andExpect(status().isBadRequest());
     }
 
@@ -72,10 +70,9 @@ public class TaskControllerValidationTest {
         """;
 
         mockMvc.perform(post("/tasks")
-                        .header("X-USER-ID", "Santi")
+                        .requestAttr("userId", "Santi")
                         .contentType("application/json")
                         .content(body))
-                .andDo(print())
                 .andExpect(status().isBadRequest());
     }
 


### PR DESCRIPTION
### Overview
This PR introduces JWT-based authentication into the `tasks-svc`.  
All endpoints now require a valid JWT token, issued by `auth-svc`.

### Changes
- Added dependencies: Spring Security + JJWT (api, impl, jackson).
- Implemented `JwtFilter`:
  - Validates JWT signature, expiration and subject.
  - Sets `Authentication` into `SecurityContext`.
- Added `SecurityConfig`:
  - Stateless `SecurityFilterChain` with `SessionCreationPolicy.STATELESS`.
  - Disabled CSRF, httpBasic, formLogin, logout, and requestCache.
  - Registered `JwtFilter` before `UsernamePasswordAuthenticationFilter`.
- Updated `TaskController`:
  - Extracts `userId` from `request` (set by `JwtFilter`) instead of custom header.
- Added `jwt.secret` property and debug logging for easier troubleshooting.

### Result
- Requests without token → return `401 Unauthorized`.
- Requests with invalid/expired token → return `401 Unauthorized`.
- Requests with valid token → proceed with authenticated `userId`.

This closes the initial integration of security into the `tasks-svc`.