### PR TITLE
feat: unify HTTP responses, JWT handling, Docker images, and Postman tests

### DIFF
--- a/api-task.postman_collection.json
+++ b/api-task.postman_collection.json
@@ -1,0 +1,273 @@
+{
+  "info": {
+    "_postman_id": "c2a9d2c8-4b52-4b9e-9921-6a5b6c8e0001",
+    "name": "TaskManager API",
+    "description": "# 🧪 TaskManager Postman Collection\n\nFlujo completo: **Register → Login (guarda token) → Create Task → List/GET/PATCH/DELETE**.\n\n- Variables:\n  - `auth_base`: http://localhost:8083\n  - `tasks_base`: http://localhost:8080\n  - `token`: se setea en **Login** automáticamente\n  - `task_id`: se setea al **crear** una tarea\n\nAutorización a nivel de colección: **Bearer {{token}}** (Register/Login usan **No Auth**).\n",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "santi-local"
+  },
+  "item": [
+    {
+      "name": "Auth - Register",
+      "request": {
+        "auth": { "type": "noauth" },
+        "method": "POST",
+        "header": [{ "key": "Content-Type", "value": "application/json" }],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"username\": \"maria\",\n  \"password\": \"supersecret456\",\n  \"email\": \"maria@example.com\"\n}"
+        },
+        "url": {
+          "raw": "{{auth_base}}/auth/register",
+          "host": ["{{auth_base}}"],
+          "path": ["auth", "register"]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Register 200/201', function () { pm.expect(pm.response.code).to.be.oneOf([200, 201]); });"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Auth - Login (sets {{token}})",
+      "request": {
+        "auth": { "type": "noauth" },
+        "method": "POST",
+        "header": [{ "key": "Content-Type", "value": "application/json" }],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"email\": \"maria@example.com\",\n  \"password\": \"supersecret456\"\n}"
+        },
+        "url": {
+          "raw": "{{auth_base}}/auth/login",
+          "host": ["{{auth_base}}"],
+          "path": ["auth", "login"]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Login 200', () => pm.response.to.have.status(200));",
+              "const data = pm.response.json();",
+              "pm.expect(data).to.have.property('token');",
+              "// Guarda token a nivel de COLECCIÓN",
+              "pm.collectionVariables.set('token', data.token);",
+              "pm.test('Token saved to {{token}}', () => pm.expect(pm.collectionVariables.get('token')).to.exist);"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Tasks - Create",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "if (!pm.collectionVariables.get('token')) {",
+              "  postman.setNextRequest('Auth - Login (sets {{token}})');",
+              "}"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Created 201', function () { pm.response.to.have.status(201); });",
+              "pm.test('Has Location header', function () { pm.expect(pm.response.headers.has('Location')).to.be.true; });",
+              "const data = pm.response.json();",
+              "pm.collectionVariables.set('task_id', data.id);",
+              "pm.test('task_id stored', function () { pm.expect(pm.collectionVariables.get('task_id')).to.exist; });"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [{ "key": "Content-Type", "value": "application/json" }],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"title\": \"Primera tarea\",\n  \"description\": \"Creada desde Postman\"\n}"
+        },
+        "url": {
+          "raw": "{{tasks_base}}/tasks",
+          "host": ["{{tasks_base}}"],
+          "path": ["tasks"]
+        }
+      }
+    },
+    {
+      "name": "Tasks - List (filters + pagination)",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{tasks_base}}/tasks?status={{status}}&priority={{priority}}&tags={{tags}}&createdFrom={{createdFrom}}&createdTo={{createdTo}}&page={{page}}&size={{size}}&sort={{sort}}",
+          "host": ["{{tasks_base}}"],
+          "path": ["tasks"],
+          "query": [
+            { "key": "status", "value": "{{status}}", "disabled": false },
+            { "key": "priority", "value": "{{priority}}", "disabled": false },
+            { "key": "tags", "value": "{{tags}}", "disabled": false },
+            { "key": "createdFrom", "value": "{{createdFrom}}", "disabled": false },
+            { "key": "createdTo", "value": "{{createdTo}}", "disabled": false },
+            { "key": "page", "value": "{{page}}" },
+            { "key": "size", "value": "{{size}}" },
+            { "key": "sort", "value": "{{sort}}" }
+          ]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('List 200', () => pm.response.to.have.status(200));"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Tasks - Get by ID",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{tasks_base}}/tasks/{{task_id}}",
+          "host": ["{{tasks_base}}"],
+          "path": ["tasks", "{{task_id}}"]
+        }
+      },
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "if (!pm.collectionVariables.get('task_id')) {",
+              "  throw new Error('task_id vacío. Crea una tarea primero.');",
+              "}"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Get 200', () => pm.response.to.have.status(200));"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Tasks - Patch",
+      "request": {
+        "method": "PATCH",
+        "header": [{ "key": "Content-Type", "value": "application/json" }],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"title\": \"Primera tarea (edit)\",\n  \"status\": \"IN_PROGRESS\",\n  \"priority\": \"MEDIUM\"\n}"
+        },
+        "url": {
+          "raw": "{{tasks_base}}/tasks/{{task_id}}",
+          "host": ["{{tasks_base}}"],
+          "path": ["tasks", "{{task_id}}"]
+        }
+      },
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "if (!pm.collectionVariables.get('task_id')) {",
+              "  throw new Error('task_id vacío. Crea una tarea primero.');",
+              "}"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Patch 200', () => pm.response.to.have.status(200));"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Tasks - Delete",
+      "request": {
+        "method": "DELETE",
+        "header": [],
+        "url": {
+          "raw": "{{tasks_base}}/tasks/{{task_id}}",
+          "host": ["{{tasks_base}}"],
+          "path": ["tasks", "{{task_id}}"]
+        }
+      },
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "if (!pm.collectionVariables.get('task_id')) {",
+              "  throw new Error('task_id vacío. Crea una tarea primero.');",
+              "}"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Delete 200/204', () => pm.expect(pm.response.code).to.be.oneOf([200,204]));",
+              "pm.collectionVariables.unset('task_id');"
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "auth": {
+    "type": "bearer",
+    "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }]
+  },
+  "event": [],
+  "variable": [
+    { "key": "auth_base", "value": "http://localhost:8083" },
+    { "key": "tasks_base", "value": "http://localhost:8080" },
+    { "key": "token", "value": "" },
+    { "key": "task_id", "value": "" },
+    { "key": "status", "value": "PENDING" },
+    { "key": "priority", "value": "HIGH" },
+    { "key": "tags", "value": "docs" },
+    { "key": "page", "value": "0" },
+    { "key": "size", "value": "20" },
+    { "key": "createdFrom", "value": "2025-09-01T00:00:00Z" },
+    { "key": "createdTo", "value": "2025-09-30T23:59:59Z" },
+    { "key": "sort", "value": "createdAt,desc" }
+  ]
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -31,7 +31,7 @@ services:
       - mongo
 
   tasks-svc:
-    image: miusuario/tasks-svc:0.0.1
+    image: santiagodt/tasks-svc:0.0.1
     env_file:
       - tasks-svc/.env
     depends_on:
@@ -41,7 +41,7 @@ services:
     restart: unless-stopped
 
   auth-svc:
-    image: miusuario/auth-svc:0.0.1
+    image: santiagodt/auth-svc:0.0.1
     env_file:
       - auth-svc/.env
     depends_on:

--- a/tasks-svc/src/main/java/com/santiago/tasks/config/SecurityConfig.java
+++ b/tasks-svc/src/main/java/com/santiago/tasks/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.santiago.tasks.config;
 
 
+import com.santiago.tasks.security.JwtAuthEntryPoint;
 import com.santiago.tasks.security.JwtFilter;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
@@ -14,9 +15,11 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtFilter jwtFilter;
+    private final JwtAuthEntryPoint jwtAuthEntryPoint;
 
-    public SecurityConfig(JwtFilter jwtFilter) {
+    public SecurityConfig(JwtFilter jwtFilter, JwtAuthEntryPoint jwtAuthEntryPoint) {
         this.jwtFilter = jwtFilter;
+        this.jwtAuthEntryPoint = jwtAuthEntryPoint;
     }
 
     @Bean
@@ -26,9 +29,7 @@ public class SecurityConfig {
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .requestCache(rc -> rc.disable())
                 .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
-                .exceptionHandling(ex -> ex.authenticationEntryPoint(
-                        (req, res, e) -> res.sendError(HttpServletResponse.SC_UNAUTHORIZED)
-                ))
+                .exceptionHandling(ex -> ex.authenticationEntryPoint(jwtAuthEntryPoint))
                 .httpBasic(b -> b.disable())
                 .formLogin(f -> f.disable())
                 .logout(l -> l.disable())

--- a/tasks-svc/src/main/java/com/santiago/tasks/controller/TaskController.java
+++ b/tasks-svc/src/main/java/com/santiago/tasks/controller/TaskController.java
@@ -14,6 +14,9 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.Instant;
 import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import java.net.URI;
 
 
 @RestController
@@ -24,21 +27,30 @@ public class TaskController {
     private TaskService taskService;
 
     @PostMapping
-    public Task createTask(
+    public ResponseEntity<Task> createTask(
             HttpServletRequest request,
             @Valid @RequestBody CreateTaskRequest taskRequest) {
         String userId = request.getAttribute("userId").toString();
-        return taskService.createTask(userId, taskRequest);
+        Task task = taskService.createTask(userId, taskRequest);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(task.getId())
+                .toUri();
+
+        return ResponseEntity.created(location).body(task);
     }
 
     @GetMapping("/{taskId}")
-    public Task getTask(HttpServletRequest request, @PathVariable String taskId) {
+    public ResponseEntity<Task> getTask(HttpServletRequest request, @PathVariable String taskId) {
         String userId = request.getAttribute("userId").toString();
-        return taskService.getTask(userId, taskId);
+        Task task = taskService.getTask(userId, taskId);
+        return ResponseEntity.ok(task);
     }
 
     @GetMapping
-    public Page<Task> getTasks(HttpServletRequest request,
+    public ResponseEntity<Page<Task>> getTasks(HttpServletRequest request,
             Pageable pageable,
             @RequestParam(required = false) Task.Status status,
             @RequestParam(required = false) Task.Priority priority,
@@ -47,19 +59,22 @@ public class TaskController {
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant createdTo
     ) {
         String userId = request.getAttribute("userId").toString();
-        return taskService.getTasks(userId, pageable, status, priority, tags, createdFrom, createdTo);
+        Page<Task> page = taskService.getTasks(userId, pageable, status, priority, tags, createdFrom, createdTo);
+        return ResponseEntity.ok(page);
     }
 
     @DeleteMapping("/{taskId}")
-    public void deleteTask(HttpServletRequest request , @PathVariable String taskId) {
+    public ResponseEntity<Void> deleteTask(HttpServletRequest request , @PathVariable String taskId) {
         String userId = request.getAttribute("userId").toString();
         taskService.deleteTask(userId, taskId);
+        return ResponseEntity.noContent().build();
     }
 
     @PatchMapping("/{taskId}")
-    public Task updateTask(HttpServletRequest request, @PathVariable String taskId, @RequestBody UpdateTaskRequest req) {
+    public ResponseEntity<Task> updateTask(HttpServletRequest request, @PathVariable String taskId, @RequestBody UpdateTaskRequest req) {
         String userId = request.getAttribute("userId").toString();
-        return taskService.updateTask(userId, taskId, req);
+        Task updated = taskService.updateTask(userId, taskId, req);
+        return ResponseEntity.ok(updated);
     }
 
 

--- a/tasks-svc/src/main/java/com/santiago/tasks/security/JwtAuthEntryPoint.java
+++ b/tasks-svc/src/main/java/com/santiago/tasks/security/JwtAuthEntryPoint.java
@@ -1,0 +1,35 @@
+// src/main/java/com/santiago/tasks/security/JwtAuthEntryPoint.java
+package com.santiago.tasks.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URI;
+
+@Component
+public class JwtAuthEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        String why = (String) request.getAttribute("jwt_error");
+
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.UNAUTHORIZED);
+        pd.setTitle("Unauthorized");
+        pd.setDetail(why != null ? why : "Invalid or expired JWT token");
+        pd.setType(URI.create("about:blank"));
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/problem+json");
+        new ObjectMapper().writeValue(response.getOutputStream(), pd);
+    }
+}


### PR DESCRIPTION
This PR bundles 6 small but useful changes to make the API cleaner, easier to test, and smoother to run:
	•	Docker/Compose: switched to santiagodt/* images (matches Docker Hub).
	•	Tasks Controller: now returns proper HTTP status codes with ResponseEntity.
	•	POST /tasks → 201 Created + Location header
	•	GET /tasks/:id + GET /tasks → 200 OK
	•	PATCH /tasks/:id → 200 OK
	•	DELETE /tasks/:id → 204 No Content
	•	Security: added JwtAuthEntryPoint for consistent 401 Unauthorized.
	•	JWT Filter: clears security context when token is bad/missing, sends reason in ProblemDetail.
	•	Problem+JSON: unauthorized responses now use application/problem+json with readable detail.
	•	Postman: added api-task.postman_collection.json (auth, CRUD, filters, status checks).

Why
	•	Make REST responses predictable for clients & Postman tests.
	•	Clearer error messages when auth fails.
	•	Easier deployment with Docker Hub images.

How to test
	1.	docker compose down -v && docker compose up -d (pulls new images).
	2.	Import Postman collection → Register → Login (stores {{token}}) → CRUD flow (201, 200, 204).
	3.	Try hitting endpoints without Authorization → get 401 with JSON detail.

Compatibility
	•	No breaking payload changes, just better status codes/headers.

Notes
	•	Next steps: maybe add rate limiting + OpenAPI examples for ProblemDetail.